### PR TITLE
Avoid executing getForward() if we do not operate on an actual object

### DIFF
--- a/src/Phlexible/Bundle/ElementBundle/Configurator/ElementConfigurator.php
+++ b/src/Phlexible/Bundle/ElementBundle/Configurator/ElementConfigurator.php
@@ -54,7 +54,6 @@ class ElementConfigurator implements ConfiguratorInterface
      */
     private $loader;
 
-
     /**
      * @param EventDispatcherInterface      $dispatcher
      * @param LoggerInterface               $logger

--- a/src/Phlexible/Bundle/ElementBundle/Configurator/ElementConfigurator.php
+++ b/src/Phlexible/Bundle/ElementBundle/Configurator/ElementConfigurator.php
@@ -108,12 +108,16 @@ class ElementConfigurator implements ConfiguratorInterface
         }
 
         /** @noinspection PhpUndefinedMethodInspection */
-        $forwardField = $contentElement->getMappedField()->getForward();
-        if ($forwardField) {
-            $forward = json_decode($forwardField);
-            $renderConfiguration->addFeature('forward')->setVariable('forward', $forward);
+        $mappedField = $contentElement->getMappedField();
+        if ($mappedField) {
+            $forwardField = $mappedField->getForward();
 
-            return;
+            if ($forwardField) {
+                $forward = json_decode($forwardField);
+                $renderConfiguration->addFeature('forward')->setVariable('forward', $forward);
+
+                return;
+            }
         }
 
         $renderConfiguration

--- a/src/Phlexible/Bundle/ElementBundle/Configurator/ElementConfigurator.php
+++ b/src/Phlexible/Bundle/ElementBundle/Configurator/ElementConfigurator.php
@@ -13,19 +13,17 @@ namespace Phlexible\Bundle\ElementBundle\Configurator;
 
 use Phlexible\Bundle\ElementBundle\ContentElement\ContentElementLoader;
 use Phlexible\Bundle\ElementBundle\ElementService;
-use Phlexible\Bundle\ElementRendererBundle\Configurator\ConfiguratorInterface;
 use Phlexible\Bundle\ElementRendererBundle\Configurator\Configuration;
+use Phlexible\Bundle\ElementRendererBundle\Configurator\ConfiguratorInterface;
 use Phlexible\Bundle\ElementRendererBundle\ElementRendererEvents;
 use Phlexible\Bundle\ElementRendererBundle\Event\ConfigureEvent;
-use Phlexible\Bundle\TreeBundle\ContentTree\ContentTreeManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
- * Element configurator
+ * Element configurator.
  *
  * @author Stephan Wentz <sw@brainbits.net>
  */
@@ -129,7 +127,7 @@ class ElementConfigurator implements ConfiguratorInterface
             if ($contentElement->getElementtypeTemplate()) {
                 $template = $contentElement->getElementtypeTemplate();
             } else {
-                $template = '::' . $contentElement->getElementtypeUniqueId() . '.html.twig';
+                $template = '::'.$contentElement->getElementtypeUniqueId().'.html.twig';
             }
 
             $renderConfiguration


### PR DESCRIPTION
… otherwise an "Cannot execute getForward() on null" Exception is thrown.