### PR TITLE
Inject user class into UserSearch

### DIFF
--- a/src/Phlexible/Bundle/UserBundle/Resources/config/services.yml
+++ b/src/Phlexible/Bundle/UserBundle/Resources/config/services.yml
@@ -68,5 +68,6 @@ services:
         public: false
         arguments:
             - "@phlexible_user.user_manager"
+            - "%phlexible_user.user.class%"
         tags:
             - {name: phlexible_search.provider}

--- a/src/Phlexible/Bundle/UserBundle/Search/UserSearch.php
+++ b/src/Phlexible/Bundle/UserBundle/Search/UserSearch.php
@@ -29,11 +29,18 @@ class UserSearch implements SearchProviderInterface
     private $userManager;
 
     /**
-     * @param UserManagerInterface $userManager
+     * @var string
      */
-    public function __construct(UserManagerInterface $userManager)
+    private $userClass;
+
+    /**
+     * @param UserManagerInterface $userManager
+     * @param string               $userClass
+     */
+    public function __construct(UserManagerInterface $userManager, $userClass)
     {
         $this->userManager = $userManager;
+        $this->userClass = $userClass;
     }
 
     /**
@@ -59,7 +66,7 @@ class UserSearch implements SearchProviderInterface
     {
         $users = $this->userManager->search(array('term' => $query));
 
-        $userClass = $this->getContainer()->get('phlexible_user.user.class');
+        $userClass = $this->userClass;
         /* @var UserInterface $createUser */
         $createUser = new $userClass;
         $createUser->setUsername('(unknown)');


### PR DESCRIPTION
Bugfix: In UserSearch the user class has to be injected instead of being pulled by a non-existent method.
Pls ignore Style CI complaints ;-)