### PR TITLE
Use newer compatibility mode for internet explorer

### DIFF
--- a/src/Phlexible/Bundle/GuiBundle/Resources/views/Frame/index.html.twig
+++ b/src/Phlexible/Bundle/GuiBundle/Resources/views/Frame/index.html.twig
@@ -3,7 +3,7 @@
 <head>
     <title>{{ project.title }}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=8; IE=7"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
     <link rel="icon" type="image/png" href="{{ asset("bundles/phlexiblegui/images/phlexible.png") }}">
     <link href="{{ asset("resources/css/ext-all.css", "extjs") }}" media="screen" rel="stylesheet" type="text/css"/>
     {% set theme = app.user.property("theme", "default") %}


### PR DESCRIPTION
The X-UA-Compatible meta tag can be used with a newer compatibility mode to make use of newer standards.