### PR TITLE
Fix wrong orm mapping in entity

### DIFF
--- a/src/Phlexible/Bundle/TreeBundle/Entity/TreeNode.php
+++ b/src/Phlexible/Bundle/TreeBundle/Entity/TreeNode.php
@@ -42,7 +42,6 @@ class TreeNode implements TreeNodeInterface, HierarchicalDomainObjectInterface
 
     /**
      * @var int
-     * @ORM\Column(name="parent_id", type="integer", nullable=true)
      * @ORM\ManyToOne(targetEntity="TreeNode", cascade={"persist"})
      * @ORM\JoinColumn(name="parent_id", referencedColumnName="id")
      */


### PR DESCRIPTION
This line is unnecessary. The the previous version whre it was just a "falsy" phpdoc comment